### PR TITLE
Add link WSDL das cidades que utilizam o provedor

### DIFF
--- a/lib/br_nfe/service/speedgov/v1/base.rb
+++ b/lib/br_nfe/service/speedgov/v1/base.rb
@@ -11,16 +11,13 @@ module BrNfe
 					def get_wsdl_by_city
 						{
 							# Caculé - BA 
-							# '2905008' => '',
-
-							# Sobradinho - BA 
-							# '2930774' => '',
+							'2905008' => 'http://www.speedgov.com.br/wscac/Nfes?wsdl',
 
 							# Aquiraz - CE  
 							'2301000' => 'http://www.speedgov.com.br/wsaqz/Nfes?wsdl',
 
 							# Aracati - CE  
-							# '2301109' => '',
+							'2301109' => 'http://www.speedgov.com.br/wsarc/Nfes?wsdl',
 
 							# Barbalha - CE  
 							'2301901' => 'http://www.speedgov.com.br/wsbar/Nfes?wsdl',
@@ -28,140 +25,47 @@ module BrNfe
 							# Beberibe - CE  
 							'2302206' => 'http://www.speedgov.com.br/wsbeb/Nfes?wsdl',
 
-							# Boa Viagem - CE 
-							# '2302404' => '',
-
-							# Camocim - CE 
-							# '2302602' => '',
-
-							# Canindé - CE 
-							# '2302800' => '',
-
-							# Carnaubal - CE 
-							# '2303402' => '',
-
-							# Catarina - CE 
-							# '2303600' => '',
-
-							# Chorozinho - CE 
-							# '2303956' => '',
+							# Crateús - CE 
+							'2304103' => 'http://www.speedgov.com.br/wscra/Nfes?wsdl',
 
 							# Crato - CE 
 							'2304202' => 'http://www.speedgov.com.br/wscrt/Nfes?wsdl',
 
-							# Cruz - CE 
-							# '2304251' => '',
-
-							# Fortim - CE 
-							# '2304459' => '',
-
 							# Guaraciaba do Norte - CE 
 							'2305001' => 'http://www.speedgov.com.br/wsgua/Nfes?wsdl',
 
-							# Hidrolândia - CE 
-							# '2305209' => '',
-
 							# Horizonte - CE 
-							# '2305233' => '',
-
-							# Icapui - CE 
-							# '2305357' => '',
-
-							# Ipu - CE 
-							# '2305803' => '',
-
-							# Ipueiras - CE 
-							# '2305902' => '',
-
-							# Irauçuba - CE 
-							# '2306108' => '',
+							'2305233' => 'http://www.speedgov.com.br/wshor/Nfes?wsdl',
 
 							# Itaitinga - CE 
 							'2306256' => 'http://www.speedgov.com.br/wsita/Nfes?wsdl',
-
-							# Jaguaretama - CE 
-							# '2306702' => '',
 
 							# Jijoca - CE 
 							'2307254' => 'http://www.speedgov.com.br/wsjij/Nfes?wsdl',
 
 							# Juazeiro do Norte - CE 
-							# '2307304' => '',
-
-							# Jucás - CE 
-							# '2307403' => '',
+							'2307304' => 'http://www.speedgov.com.br/wsjun/Nfes?wsdl',
 
 							# Maracanaú - CE 
 							'2307650' => 'http://www.speedgov.com.br/wsmar/Nfes?wsdl',
 
-							# Mombaça - CE 
-							# '2308500' => '',
-
-							# Morada Nova - CE 
-							# '2308708' => '',
-
-							# Monsenhor Tabosa - CE 
-							# '2308609' => '',
-
-							# Nova Russas - CE 
-							# '2309300' => '',
-
-							# Novo Oriente - CE 
-							# '2309409' => '',
-
-							# Pacajús - CE 
-							# '2309607' => '',
-
 							# Pindoretama - CE 
 							'2310852' => 'http://www.speedgov.com.br/wspin/Nfes?wsdl',
 
-							# Quiterianópolis - CE 
-							# '2311264' => '',
-
 							# Quixadá  - CE 
-							# '2311306' => '',
+							'2311306' => 'http://www.speedgov.com.br/wsqda/Nfes?wsdl',
 
 							# Quixeramobim - CE 
 							'2311405' => 'http://www.speedgov.com.br/wsqxb/Nfes?wsdl',
-
-							# Reriutaba - CE 
-							# '2311702' => '',
-
-							# Saboeiro - CE 
-							# '2311900' => '',
-
-							# Santa Quitéria - CE 
-							# '2312205' => '',
-
-							# Senador Pompeu - CE 
-							# '2312700' => '',
 
 							# Tauá - CE 
 							'2313302' => 'http://www.speedgov.com.br/wstau/Nfes?wsdl',
 
 							# Tianguá - CE 
-							# '2313401' => '',
-
-							# Trairi - CE 
-							# '2313500' => '',
-
-							# Ubajara - CE 
-							# '2313609' => '',
-
-							# Umirim - CE 
-							# '2313757' => '',
-
-							# Uruburetama - CE 
-							# '2313807' => '',
-
-							# Pires Ferreira - CE 
-							# '2310951' => '',
+							'2313401' => 'http://www.speedgov.com.br/wstia/Nfes?wsdl',
 
 							# Barra do Corda - MA 
-							# '2101608' => '',
-
-							# Lagoa Grande - PE 
-							# '2608750' => '',
+							'2101608' => 'http://www.speedgov.com.br/wsbco/Nfes?wsdl',
 
 							# Petrolina - PE 
 							'2611101' => 'http://www.speedgov.com.br/wspet/Nfes?wsdl',

--- a/test/br_nfe/service/speedgov/v1/base_test.rb
+++ b/test/br_nfe/service/speedgov/v1/base_test.rb
@@ -20,16 +20,10 @@ describe BrNfe::Service::Speedgov::V1::Base do
 		end
 
 		# Caculé - BA
-		# it "se codigo da cidade emitente for 2905008 então deve pagar a URL de Caculé - BA" do
-			# subject.ibge_code_of_issuer_city = '2905008'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Sobradinho - BA
-		# it "se codigo da cidade emitente for 2930774 então deve pagar a URL de Sobradinho - BA" do
-			# subject.ibge_code_of_issuer_city = '2930774'
-			# subject.wsdl.must_equal ''
-		# end
+		it "se codigo da cidade emitente for 2905008 então deve pagar a URL de Caculé - BA" do
+			subject.ibge_code_of_issuer_city = '2905008'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wscac/Nfes?wsdl'
+		end
 
 		# Aquiraz - CE 
 		it "se codigo da cidade emitente for 2301000 então deve pagar a URL de Aquiraz - CE " do
@@ -38,10 +32,10 @@ describe BrNfe::Service::Speedgov::V1::Base do
 		end
 
 		# Aracati - CE 
-		# it "se codigo da cidade emitente for 2301109 então deve pagar a URL de Aracati - CE " do
-			# subject.ibge_code_of_issuer_city = '2301109'
-			# subject.wsdl.must_equal ''
-		# end
+		it "se codigo da cidade emitente for 2301109 então deve pagar a URL de Aracati - CE " do
+			subject.ibge_code_of_issuer_city = '2301109'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsarc/Nfes?wsdl'
+		end
 
 		# Barbalha - CE 
 		it "se codigo da cidade emitente for 2301901 então deve pagar a URL de Barbalha - CE " do
@@ -55,41 +49,11 @@ describe BrNfe::Service::Speedgov::V1::Base do
 			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsbeb/Nfes?wsdl'
 		end
 
-		# Boa Viagem - CE
-		# it "se codigo da cidade emitente for 2302404 então deve pagar a URL de Boa Viagem - CE" do
-			# subject.ibge_code_of_issuer_city = '2302404'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Camocim - CE
-		# it "se codigo da cidade emitente for 2302602 então deve pagar a URL de Camocim - CE" do
-			# subject.ibge_code_of_issuer_city = '2302602'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Canindé - CE
-		# it "se codigo da cidade emitente for 2302800 então deve pagar a URL de Canindé - CE" do
-			# subject.ibge_code_of_issuer_city = '2302800'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Carnaubal - CE
-		# it "se codigo da cidade emitente for 2303402 então deve pagar a URL de Carnaubal - CE" do
-			# subject.ibge_code_of_issuer_city = '2303402'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Catarina - CE
-		# it "se codigo da cidade emitente for 2303600 então deve pagar a URL de Catarina - CE" do
-			# subject.ibge_code_of_issuer_city = '2303600'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Chorozinho - CE
-		# it "se codigo da cidade emitente for 2303956 então deve pagar a URL de Chorozinho - CE" do
-			# subject.ibge_code_of_issuer_city = '2303956'
-			# subject.wsdl.must_equal ''
-		# end
+		# Crateús - CE
+		it "se codigo da cidade emitente for 2304103 então deve pagar a URL de Crateús - CE" do
+			subject.ibge_code_of_issuer_city = '2304103'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wscra/Nfes?wsdl'
+		end
 
 		# Crato - CE
 		it "se codigo da cidade emitente for 2304202 então deve pagar a URL de Crato - CE" do
@@ -97,71 +61,23 @@ describe BrNfe::Service::Speedgov::V1::Base do
 			subject.wsdl.must_equal 'http://www.speedgov.com.br/wscrt/Nfes?wsdl'
 		end
 
-		# Cruz - CE
-		# it "se codigo da cidade emitente for 2304251 então deve pagar a URL de Cruz - CE" do
-			# subject.ibge_code_of_issuer_city = '2304251'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Fortim - CE
-		# it "se codigo da cidade emitente for 2304459 então deve pagar a URL de Fortim - CE" do
-			# subject.ibge_code_of_issuer_city = '2304459'
-			# subject.wsdl.must_equal ''
-		# end
-
 		# Guaraciaba do Norte - CE
 		it "se codigo da cidade emitente for 2305001 então deve pagar a URL de Guaraciaba do Norte - CE" do
 			subject.ibge_code_of_issuer_city = '2305001'
 			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsgua/Nfes?wsdl'
 		end
 
-		# Hidrolândia - CE
-		# it "se codigo da cidade emitente for 2305209 então deve pagar a URL de Hidrolândia - CE" do
-			# subject.ibge_code_of_issuer_city = '2305209'
-			# subject.wsdl.must_equal ''
-		# end
-
 		# Horizonte - CE
-		# it "se codigo da cidade emitente for 2305233 então deve pagar a URL de Horizonte - CE" do
-			# subject.ibge_code_of_issuer_city = '2305233'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Icapui - CE
-		# it "se codigo da cidade emitente for 2305357 então deve pagar a URL de Icapui - CE" do
-			# subject.ibge_code_of_issuer_city = '2305357'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Ipu - CE
-		# it "se codigo da cidade emitente for 2305803 então deve pagar a URL de Ipu - CE" do
-			# subject.ibge_code_of_issuer_city = '2305803'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Ipueiras - CE
-		# it "se codigo da cidade emitente for 2305902 então deve pagar a URL de Ipueiras - CE" do
-			# subject.ibge_code_of_issuer_city = '2305902'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Irauçuba - CE
-		# it "se codigo da cidade emitente for 2306108 então deve pagar a URL de Irauçuba - CE" do
-			# subject.ibge_code_of_issuer_city = '2306108'
-			# subject.wsdl.must_equal ''
-		# end
+		it "se codigo da cidade emitente for 2305233 então deve pagar a URL de Horizonte - CE" do
+			subject.ibge_code_of_issuer_city = '2305233'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wshor/Nfes?wsdl'
+		end
 
 		# Itaitinga - CE
 		it "se codigo da cidade emitente for 2306256 então deve pagar a URL de Itaitinga - CE" do
 			subject.ibge_code_of_issuer_city = '2306256'
 			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsita/Nfes?wsdl'
 		end
-
-		# Jaguaretama - CE
-		# it "se codigo da cidade emitente for 2306702 então deve pagar a URL de Jaguaretama - CE" do
-			# subject.ibge_code_of_issuer_city = '2306702'
-			# subject.wsdl.must_equal ''
-		# end
 
 		# Jijoca - CE
 		it "se codigo da cidade emitente for 2307254 então deve pagar a URL de Jijoca - CE" do
@@ -170,16 +86,10 @@ describe BrNfe::Service::Speedgov::V1::Base do
 		end
 
 		# Juazeiro do Norte - CE
-		# it "se codigo da cidade emitente for 2307304 então deve pagar a URL de Juazeiro do Norte - CE" do
-			# subject.ibge_code_of_issuer_city = '2307304'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Jucás - CE
-		# it "se codigo da cidade emitente for 2307403 então deve pagar a URL de Jucás - CE" do
-			# subject.ibge_code_of_issuer_city = '2307403'
-			# subject.wsdl.must_equal ''
-		# end
+		it "se codigo da cidade emitente for 2307304 então deve pagar a URL de Juazeiro do Norte - CE" do
+			subject.ibge_code_of_issuer_city = '2307304'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsjun/Nfes?wsdl'
+		end
 
 		# Maracanaú - CE
 		it "se codigo da cidade emitente for 2307650 então deve pagar a URL de Maracanaú - CE" do
@@ -187,89 +97,23 @@ describe BrNfe::Service::Speedgov::V1::Base do
 			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsmar/Nfes?wsdl'
 		end
 
-		# Mombaça - CE
-		# it "se codigo da cidade emitente for 2308500 então deve pagar a URL de Mombaça - CE" do
-			# subject.ibge_code_of_issuer_city = '2308500'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Morada Nova - CE
-		# it "se codigo da cidade emitente for 2308708 então deve pagar a URL de Morada Nova - CE" do
-			# subject.ibge_code_of_issuer_city = '2308708'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Monsenhor Tabosa - CE
-		# it "se codigo da cidade emitente for 2308609 então deve pagar a URL de Monsenhor Tabosa - CE" do
-			# subject.ibge_code_of_issuer_city = '2308609'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Nova Russas - CE
-		# it "se codigo da cidade emitente for 2309300 então deve pagar a URL de Nova Russas - CE" do
-			# subject.ibge_code_of_issuer_city = '2309300'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Novo Oriente - CE
-		# it "se codigo da cidade emitente for 2309409 então deve pagar a URL de Novo Oriente - CE" do
-			# subject.ibge_code_of_issuer_city = '2309409'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Pacajús - CE
-		# it "se codigo da cidade emitente for 2309607 então deve pagar a URL de Pacajús - CE" do
-			# subject.ibge_code_of_issuer_city = '2309607'
-			# subject.wsdl.must_equal ''
-		# end
-
 		# Pindoretama - CE
 		it "se codigo da cidade emitente for 2310852 então deve pagar a URL de Pindoretama - CE" do
 			subject.ibge_code_of_issuer_city = '2310852'
 			subject.wsdl.must_equal 'http://www.speedgov.com.br/wspin/Nfes?wsdl'
 		end
 
-		# Quiterianópolis - CE
-		# it "se codigo da cidade emitente for 2311264 então deve pagar a URL de Quiterianópolis - CE" do
-			# subject.ibge_code_of_issuer_city = '2311264'
-			# subject.wsdl.must_equal ''
-		# end
-
 		# Quixadá  - CE
-		# it "se codigo da cidade emitente for 2311306 então deve pagar a URL de Quixadá  - CE" do
-			# subject.ibge_code_of_issuer_city = '2311306'
-			# subject.wsdl.must_equal ''
-		# end
+		it "se codigo da cidade emitente for 2311306 então deve pagar a URL de Quixadá  - CE" do
+			subject.ibge_code_of_issuer_city = '2311306'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsqda/Nfes?wsdl'
+		end
 
 		# Quixeramobim - CE
 		it "se codigo da cidade emitente for 2311405 então deve pagar a URL de Quixeramobim - CE" do
 			subject.ibge_code_of_issuer_city = '2311405'
 			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsqxb/Nfes?wsdl'
 		end
-
-		# Reriutaba - CE
-		# it "se codigo da cidade emitente for 2311702 então deve pagar a URL de Reriutaba - CE" do
-			# subject.ibge_code_of_issuer_city = '2311702'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Saboeiro - CE
-		# it "se codigo da cidade emitente for 2311900 então deve pagar a URL de Saboeiro - CE" do
-			# subject.ibge_code_of_issuer_city = '2311900'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Santa Quitéria - CE
-		# it "se codigo da cidade emitente for 2312205 então deve pagar a URL de Santa Quitéria - CE" do
-			# subject.ibge_code_of_issuer_city = '2312205'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Senador Pompeu - CE
-		# it "se codigo da cidade emitente for 2312700 então deve pagar a URL de Senador Pompeu - CE" do
-			# subject.ibge_code_of_issuer_city = '2312700'
-			# subject.wsdl.must_equal ''
-		# end
 
 		# Tauá - CE
 		it "se codigo da cidade emitente for 2313302 então deve pagar a URL de Tauá - CE" do
@@ -278,52 +122,16 @@ describe BrNfe::Service::Speedgov::V1::Base do
 		end
 
 		# Tianguá - CE
-		# it "se codigo da cidade emitente for 2313401 então deve pagar a URL de Tianguá - CE" do
-			# subject.ibge_code_of_issuer_city = '2313401'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Trairi - CE
-		# it "se codigo da cidade emitente for 2313500 então deve pagar a URL de Trairi - CE" do
-			# subject.ibge_code_of_issuer_city = '2313500'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Ubajara - CE
-		# it "se codigo da cidade emitente for 2313609 então deve pagar a URL de Ubajara - CE" do
-			# subject.ibge_code_of_issuer_city = '2313609'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Umirim - CE
-		# it "se codigo da cidade emitente for 2313757 então deve pagar a URL de Umirim - CE" do
-			# subject.ibge_code_of_issuer_city = '2313757'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Uruburetama - CE
-		# it "se codigo da cidade emitente for 2313807 então deve pagar a URL de Uruburetama - CE" do
-			# subject.ibge_code_of_issuer_city = '2313807'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Pires Ferreira - CE
-		# it "se codigo da cidade emitente for 2310951 então deve pagar a URL de Pires Ferreira - CE" do
-			# subject.ibge_code_of_issuer_city = '2310951'
-			# subject.wsdl.must_equal ''
-		# end
+		it "se codigo da cidade emitente for 2313401 então deve pagar a URL de Tianguá - CE" do
+			subject.ibge_code_of_issuer_city = '2313401'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wstia/Nfes?wsdl'
+		end
 
 		# Barra do Corda - MA
-		# it "se codigo da cidade emitente for 2101608 então deve pagar a URL de Barra do Corda - MA" do
-			# subject.ibge_code_of_issuer_city = '2101608'
-			# subject.wsdl.must_equal ''
-		# end
-
-		# Lagoa Grande - PE
-		# it "se codigo da cidade emitente for 2608750 então deve pagar a URL de Lagoa Grande - PE" do
-			# subject.ibge_code_of_issuer_city = '2608750'
-			# subject.wsdl.must_equal ''
-		# end
+		it "se codigo da cidade emitente for 2101608 então deve pagar a URL de Barra do Corda - MA" do
+			subject.ibge_code_of_issuer_city = '2101608'
+			subject.wsdl.must_equal 'http://www.speedgov.com.br/wsbco/Nfes?wsdl'
+		end
 
 		# Petrolina - PE
 		it "se codigo da cidade emitente for 2611101 então deve pagar a URL de Petrolina - PE" do


### PR DESCRIPTION
# SpeedGov

## Cidades que o provedor abrange
- http://servicos.speedgov.com.br/selecione

## Cidades que utilizam Web Service
### Bahia
- Caculé - BA

### Ceará
- Aquiraz - CE 
- Aracati - CE
- Barbalha - CE 
- Beberibe - CE 
- Crateús - CE
- Crato - CE
- Guaraciaba do Norte - CE
- Horizonte - CE
- Ipu - CE
- Itaitinga - CE
- Jijoca - CE
- Juazeiro do Norte - CE
- Maracanaú - CE
- Pindoretama - CE
- Quiterianópolis - CE
- Quixadá  - CE
- Quixeramobim - CE
- Tauá - CE
- Tianguá - CE

### Maranhão
- Barra do Corda - MA

### Pernambuco
- Petrolina - PE